### PR TITLE
Remove bicc note, keep price note

### DIFF
--- a/src/pages/Planner.tsx
+++ b/src/pages/Planner.tsx
@@ -1118,24 +1118,6 @@ const Planner = () => {
             )}
           </div>
 
-        {/* Transaction Fee Note for BICC School */}
-        {profile?.data?.school?.name && profile.data.school.name.toLowerCase().includes('bicc') && (
-          <div className="mb-6 flex justify-center">
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 max-w-md">
-              <div className="flex items-start space-x-2">
-                <div className="w-5 h-5 text-blue-500 mt-0.5 flex-shrink-0">
-                  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                    <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
-                  </svg>
-                </div>
-                <div className="text-sm text-blue-700">
-                  <p className="font-medium mb-1">Note</p>
-                  <p>Prices include transaction fees</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
 
         {generalFilter === "meals" && (
           <>

--- a/src/pages/Planner.tsx
+++ b/src/pages/Planner.tsx
@@ -1112,9 +1112,20 @@ const Planner = () => {
             View Full Menu
             </Button>
             {schoolName && schoolName.toLowerCase().includes('bicc') && (
-              <p className="text-sm text-gray-600 mt-2 text-center max-w-md">
-                * Prices include transaction fees
-              </p>
+              <div className="mt-3 flex justify-center">
+                <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 max-w-md">
+                  <div className="flex items-center space-x-2">
+                    <div className="w-4 h-4 text-amber-500 flex-shrink-0">
+                      <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                        <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+                      </svg>
+                    </div>
+                    <p className="text-sm text-amber-700 font-medium">
+                      Prices include transaction fees
+                    </p>
+                  </div>
+                </div>
+              </div>
             )}
           </div>
 


### PR DESCRIPTION
Remove redundant styled transaction fee note for BICC school.

---
<a href="https://cursor.com/background-agent?bcId=bc-2800f68d-c377-4bfb-9193-18de8c62395c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2800f68d-c377-4bfb-9193-18de8c62395c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

