### PR TITLE
Fix phone field name mismatch

### DIFF
--- a/src/components/PaymentForm.tsx
+++ b/src/components/PaymentForm.tsx
@@ -13,7 +13,7 @@ const PaymentForm: React.FC<PaymentFormProps> = ({ onSubmit }) => {
     first_name: '',
     last_name: '',
     email: '',
-    phone_number: '',
+    phone: '',
     apartment: '',
     floor: '',
     street: '',
@@ -72,8 +72,8 @@ const PaymentForm: React.FC<PaymentFormProps> = ({ onSubmit }) => {
           <Input
             type="tel"
             placeholder="Phone Number"
-            value={billingData.phone_number}
-            onChange={(e) => handleInputChange('phone_number', e.target.value)}
+            value={billingData.phone}
+            onChange={(e) => handleInputChange('phone', e.target.value)}
             required
           />
           

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -11,7 +11,7 @@ export interface BillingData {
   first_name: string;
   last_name: string;
   email: string;
-  phone_number: string;
+  phone: string;
   apartment: string;
   floor: string;
   street: string;


### PR DESCRIPTION
Align frontend phone field name with backend to resolve `preg_match()` error during Paymob payment processing.

---
<a href="https://cursor.com/background-agent?bcId=bc-a4eb7316-5f8f-485b-94cf-170f8cd2d96f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a4eb7316-5f8f-485b-94cf-170f8cd2d96f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

