### PR TITLE
Update payment types for unified intention api

### DIFF
--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -37,7 +37,9 @@ export interface PaymentResponse {
   success: boolean;
   data?: {
     transaction: any;
-    payment_url: string;
+    payment_url: string;        // ← This stays the same ✅
+    payment_intent_id?: string; // ← Add this for new API
+    transaction_id?: string;    // ← Add this for new API
   };
   message?: string;
 }


### PR DESCRIPTION
Update `PaymentResponse` interface to support the new Unified Intention API.

This adds `payment_intent_id` and `transaction_id` fields, while retaining the existing `payment_url` field, ensuring the frontend is compatible with the new API without breaking current payment flows.

---
<a href="https://cursor.com/background-agent?bcId=bc-af7027c4-1f73-40d7-a70e-c6b10ea567e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-af7027c4-1f73-40d7-a70e-c6b10ea567e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

