### PR TITLE
Update wallet recharge to use new api

### DIFF
--- a/src/pages/Recharge.tsx
+++ b/src/pages/Recharge.tsx
@@ -317,29 +317,43 @@ const Recharge = () => {
       const finalAmount = parseFloat(amount) || 0;
       const formattedPhone = PaymentService.formatPhoneNumber(paymobCardDetails.phone_number);
 
-      const response = await PaymentService.initiatePayment({
+      const response = await walletApi.recharge({
         amount: finalAmount,
         payment_method: 'paymob_card',
-        first_name: paymobCardDetails.first_name,
-        last_name: paymobCardDetails.last_name,
-        email: paymobCardDetails.email,
-        phone_number: formattedPhone,
-        city: paymobCardDetails.city,
-        country: paymobCardDetails.country,
-        userId: profile.id
+        payment_details: {
+          order_id: `wallet_recharge_${Date.now()}`,
+          item_name: 'Wallet Recharge',
+          description: 'Digital wallet top-up',
+          merchant_order_id: `recharge_${Date.now()}_${profile.id}`,
+          currency: 'EGP',
+          billing_data: {
+            first_name: paymobCardDetails.first_name,
+            last_name: paymobCardDetails.last_name,
+            email: paymobCardDetails.email,
+            phone_number: formattedPhone,
+            apartment: paymobCardDetails.apartment || '',
+            floor: paymobCardDetails.floor || '',
+            street: paymobCardDetails.street || '',
+            building: paymobCardDetails.building || '',
+            city: paymobCardDetails.city,
+            state: paymobCardDetails.state || 'Cairo',
+            country: 'EG',
+            postal_code: paymobCardDetails.postal_code || '12345'
+          }
+        }
       });
 
-      if (response.success && response.data?.checkout_url) {
+      if (response.data.success && response.data.payment_url) {
         // Save payment method if user opted to save
         if (paymobCardDetails.save_card) {
           savePaymentMethod('card', paymobCardDetails);
         }
 
         // Redirect to Paymob checkout page
-        window.location.href = response.data.checkout_url;
+        window.location.href = response.data.payment_url;
         setShowCardModal(false);
       } else {
-        toast.error(response.message || 'Failed to initiate payment');
+        toast.error(response.data.message || 'Failed to initiate payment');
       }
     } catch (error: any) {
       console.error('Paymob card payment error:', error);
@@ -376,29 +390,43 @@ const Recharge = () => {
       const finalAmount = parseFloat(amount) || 0;
       const formattedPhone = PaymentService.formatPhoneNumber(paymobWalletDetails.phone_number);
 
-      const response = await PaymentService.initiatePayment({
+      const response = await walletApi.recharge({
         amount: finalAmount,
         payment_method: 'paymob_wallet',
-        first_name: paymobWalletDetails.first_name,
-        last_name: paymobWalletDetails.last_name,
-        email: paymobWalletDetails.email,
-        phone_number: formattedPhone,
-        city: 'Cairo',
-        country: 'EG',
-        userId: profile.id
+        payment_details: {
+          order_id: `wallet_recharge_${Date.now()}`,
+          item_name: 'Wallet Recharge',
+          description: 'Digital wallet top-up',
+          merchant_order_id: `recharge_${Date.now()}_${profile.id}`,
+          currency: 'EGP',
+          billing_data: {
+            first_name: paymobWalletDetails.first_name,
+            last_name: paymobWalletDetails.last_name,
+            email: paymobWalletDetails.email,
+            phone_number: formattedPhone,
+            apartment: '',
+            floor: '',
+            street: '',
+            building: '',
+            city: 'Cairo',
+            state: 'Cairo',
+            country: 'EG',
+            postal_code: '12345'
+          }
+        }
       });
 
-      if (response.success && response.data?.checkout_url) {
+      if (response.data.success && response.data.payment_url) {
         // Save payment method if user opted to save
         if (paymobWalletDetails.save_wallet) {
           savePaymentMethod('wallet', paymobWalletDetails);
         }
 
         // Redirect to Paymob checkout page
-        window.location.href = response.data.checkout_url;
+        window.location.href = response.data.payment_url;
         setShowWalletModal(false);
       } else {
-        toast.error(response.message || 'Failed to initiate payment');
+        toast.error(response.data.message || 'Failed to initiate payment');
       }
     } catch (error: any) {
       console.error('Paymob wallet payment error:', error);

--- a/src/services/walletService.ts
+++ b/src/services/walletService.ts
@@ -1,6 +1,7 @@
 import PaymentService from './paymentService';
 import { PaymentData } from './paymentService';
 import PaymentErrorHandler from '@/utils/paymentErrorHandler';
+import { walletApi } from './api';
 
 export interface WalletTopUpRequest {
   amount: number;
@@ -26,7 +27,7 @@ export interface WalletTopUpRequest {
 
 export interface WalletTopUpResponse {
   success: boolean;
-  checkout_url?: string;
+  payment_url?: string;
   intention_id?: string;
   message?: string;
 }
@@ -82,14 +83,38 @@ export class WalletService {
         })
       };
 
-      // Initiate payment
-      const response = await PaymentService.initiatePayment(paymentData);
+      // Use wallet recharge API instead of checkout API
+      const response = await walletApi.recharge({
+        amount: request.amount,
+        payment_method: request.payment_method,
+        payment_details: {
+          order_id: `wallet_recharge_${Date.now()}`,
+          item_name: 'Wallet Recharge',
+          description: 'Digital wallet top-up',
+          merchant_order_id: `recharge_${Date.now()}_${request.user_id}`,
+          currency: 'EGP',
+          billing_data: {
+            first_name: request.billing_data.first_name,
+            last_name: request.billing_data.last_name,
+            email: request.billing_data.email,
+            phone_number: formattedPhone,
+            apartment: '',
+            floor: '',
+            street: '',
+            building: '',
+            city: request.billing_data.city,
+            state: 'Cairo',
+            country: 'EG',
+            postal_code: '12345'
+          }
+        }
+      });
 
       return {
-        success: response.success,
-        checkout_url: response.data?.checkout_url,
-        intention_id: response.data?.intention_id,
-        message: response.message
+        success: response.data.success,
+        payment_url: response.data.payment_url,
+        intention_id: response.data.intention_id,
+        message: response.data.message
       };
     } catch (error: any) {
       PaymentErrorHandler.logError(error, 'Wallet Top Up');


### PR DESCRIPTION
Migrate wallet top-up functionality to use the dedicated wallet recharge API.

This updates `WalletService.topUpWallet()` and payment handlers in `Recharge.tsx` to use `walletApi.recharge()` with the correct payload structure and response handling, replacing the old `PaymentService.initiatePayment()`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c836cbc2-be92-42b3-a22b-ae03baf539e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c836cbc2-be92-42b3-a22b-ae03baf539e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

